### PR TITLE
feat: add customizations to tab-bar

### DIFF
--- a/kanagawa-theme.el
+++ b/kanagawa-theme.el
@@ -489,8 +489,11 @@
  `(hydra-face-red                                ((,class (:foreground ,peach-red))))
  `(hydra-face-teal                               ((,class (:foreground ,light-blue))))
 
+ ;; tab-bar
+ `(tab-bar                                       ((,class (:background ,sumi-ink-1b))))
+ `(tab-bar-tab-inactive                          ((,class (:foreground ,sumi-ink-4 :background ,sumi-ink-1b))))
+ 
  ;; centaur-tabs
-
  `(centaur-tabs-active-bar-face                  ((,class (:background ,spring-blue :foreground ,fuji-white))))
  `(centaur-tabs-selected                         ((,class (:background ,sumi-ink-1b :foreground ,fuji-white :weight bold))))
  `(centaur-tabs-selected-modified                ((,class (:background ,sumi-ink-1b :foreground ,fuji-white))))


### PR DESCRIPTION
Hello there!

Thanks for this really nice theme!

I was missing customizations for Emacs built-in tab-mode (C-x t 2). This PR changes this:

![image](https://github.com/meritamen/emacs-kanagawa-theme/assets/16169950/d2a47555-de74-40aa-90f5-69c288a9f9d5)

To this:

![image](https://github.com/meritamen/emacs-kanagawa-theme/assets/16169950/9a2239bf-782c-42ba-b2f3-11ec251c31a3)
